### PR TITLE
Support smartphones

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,10 +19,12 @@
 </header>
 
 <main>
-  <div id="square">
-    <div id="band"></div>
-    <p id="JPlabel">サークル会館</p>
-    <p id="ENlabel">UEC Club House</p>
+  <div id="square-wrapper">
+    <div id="square">
+      <div id="band"></div>
+      <p id="JPlabel">サークル会館</p>
+      <p id="ENlabel">UEC Club House</p>
+    </div>
   </div>
 
   <div id="Preview">

--- a/index.html
+++ b/index.html
@@ -29,45 +29,41 @@
 
   <div id="Preview">
     <form name="Request" action="#">
-      <div style="display:flex;">
-        <div style="display:flex; margin:auto 5px auto auto;">
-          <table>
-            <caption>JP</caption>
-            <tbody style="text-align:left;">
-              <tr>
-                <td>building</td><td><input name="buildingJP" type="text" value="サークル会館"></td>
-              </tr>
-              <tr>
-                <td>font size</td><td><input name="fontsizeJP" type="number" min="10" max="100" value="65"> px</td>
-              </tr>
-              <tr>
-                <td>margin-top</td><td><input name="TpositionJP" type="number" min="0" max="500" value="33"> px</td>
-              </tr>
-              <tr>
-                <td>margin-left</td><td><input name="LpositionJP" type="number" min="0" max="500" value="71"> px</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-        <div style="display:flex; margin:auto auto auto 5px;">
-          <table>
-            <caption>EN</caption>
-            <tbody style="text-align:left;">
-              <tr>
-                <td>building</td><td><input name="buildingEN" type="text" value="UEC Club House"></td>
-              </tr>
-              <tr>
-                <td>font size</td><td><input name="fontsizeEN" type="number" min="10" max="100" value="36"> px</td>
-              </tr>
-              <tr>
-                <td>margin-top</td><td><input name="TpositionEN" type="number" min="0" max="500" value="112"> px</td>
-              </tr>
-              <tr>
-                <td>margin-left</td><td><input name="LpositionEN" type="number" min="0" max="500" value="72"> px</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
+      <div id="FormTables">
+        <table>
+          <caption>JP</caption>
+          <tbody style="text-align:left;">
+          <tr>
+            <td>building</td><td><input name="buildingJP" type="text" value="サークル会館"></td>
+          </tr>
+          <tr>
+            <td>font size</td><td><input name="fontsizeJP" type="number" min="10" max="100" value="65"> px</td>
+          </tr>
+          <tr>
+            <td>margin-top</td><td><input name="TpositionJP" type="number" min="0" max="500" value="33"> px</td>
+          </tr>
+          <tr>
+            <td>margin-left</td><td><input name="LpositionJP" type="number" min="0" max="500" value="71"> px</td>
+          </tr>
+          </tbody>
+        </table>
+        <table>
+          <caption>EN</caption>
+          <tbody style="text-align:left;">
+          <tr>
+            <td>building</td><td><input name="buildingEN" type="text" value="UEC Club House"></td>
+          </tr>
+          <tr>
+            <td>font size</td><td><input name="fontsizeEN" type="number" min="10" max="100" value="36"> px</td>
+          </tr>
+          <tr>
+            <td>margin-top</td><td><input name="TpositionEN" type="number" min="0" max="500" value="112"> px</td>
+          </tr>
+          <tr>
+            <td>margin-left</td><td><input name="LpositionEN" type="number" min="0" max="500" value="72"> px</td>
+          </tr>
+          </tbody>
+        </table>
       </div>
       <div style="margin-top:15px; text-align:center;">
         <input type="button" value="Preview" onclick="previewer()">

--- a/script.js
+++ b/script.js
@@ -17,6 +17,8 @@ async function generateCanvas(){
 
   // Restore the original ratio.
   $(":root").css("--scale-ratio", "");
+
+  return canvas;
 }
 
 function GenAndDL(){

--- a/script.js
+++ b/script.js
@@ -10,7 +10,13 @@ function previewer() {
 }
 
 function generator(){
+  // Set --scale-ratio to 1 so that html2canvas will work properly.
+  $(":root").css("--scale-ratio", "1");
+
   html2canvas(document.querySelector('#square')).then(function(canvas) {
+    // Restore the original ratio.
+    $(":root").css("--scale-ratio", "");
+
     let element = document.querySelector('#Display');
     while(element.firstChild){
       element.removeChild(element.firstChild);

--- a/style.css
+++ b/style.css
@@ -102,11 +102,6 @@ footer {
   }
 }
 
-#Generate {
-  margin:30px auto;
-  text-align:center;
-}
-
 #GenerateAndDownload {
   margin:50px auto;
   text-align:center;

--- a/style.css
+++ b/style.css
@@ -107,25 +107,6 @@ footer {
   text-align:center;
 }
 
-#Display {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-
-  margin:30px auto;
-  padding:5px;
-  border:thick double #32a1ce;
-
-  height:var(--displayed-side-length);
-  width:var(--displayed-side-length);
-}
-
-#Display canvas {
-  display: flex;
-  margin:0 auto;
-  transform:scale(var(--scale-ratio));
-}
-
 #GenerateAndDownload {
   margin:50px auto;
   text-align:center;

--- a/style.css
+++ b/style.css
@@ -104,10 +104,22 @@ footer {
 }
 
 #Display {
-   margin:30px auto;
-   padding:15px;
-   border:thick double #32a1ce;
-   text-align:center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  margin:30px auto;
+  padding:15px;
+  border:thick double #32a1ce;
+
+  height:var(--displayed-side-length);
+  width:var(--displayed-side-length);
+}
+
+#Display canvas {
+  margin:0 auto;
+  transform:scale(var(--scale-ratio));
+  transform-origin:0 0;
 }
 
 #DL {

--- a/style.css
+++ b/style.css
@@ -109,7 +109,7 @@ footer {
   justify-content: center;
 
   margin:30px auto;
-  padding:15px;
+  padding:5px;
   border:thick double #32a1ce;
 
   height:var(--displayed-side-length);
@@ -117,9 +117,9 @@ footer {
 }
 
 #Display canvas {
+  display: flex;
   margin:0 auto;
   transform:scale(var(--scale-ratio));
-  transform-origin:0 0;
 }
 
 #DL {

--- a/style.css
+++ b/style.css
@@ -17,6 +17,10 @@
   }
 }
 
+body {
+  font-family: sans-serif;
+}
+
 header {
   margin-bottom:30px;
   padding-left:5px;

--- a/style.css
+++ b/style.css
@@ -77,6 +77,27 @@ footer {
   margin:30px auto;
 }
 
+#FormTables {
+  display: flex;
+  gap: 10px;
+  margin: 0 auto;
+  justify-content: center;
+}
+
+#FormTables table {
+  display: block;
+}
+
+@media screen and (max-width: 530px) {
+  #FormTables {
+    flex-direction: column;
+  }
+
+  #FormTables table {
+    margin: 0 auto;
+  }
+}
+
 #Generate {
   margin:30px auto;
   text-align:center;

--- a/style.css
+++ b/style.css
@@ -1,3 +1,22 @@
+:root {
+  --original-side-length: 500px;
+  --scale-ratio: 1;
+  --displayed-side-length:
+          calc(var(--original-side-length) * var(--scale-ratio));
+}
+
+@media screen and (max-width: 520px) {
+  :root {
+    --scale-ratio: 0.55;
+  }
+}
+
+@media screen and (max-width: 300px) {
+  :root {
+    --scale-ratio: 0.4;
+  }
+}
+
 header {
   margin-bottom:30px;
   padding-left:5px;
@@ -13,11 +32,20 @@ footer {
   text-align:center;
 }
 
+#square-wrapper {
+  margin:0 auto;
+  height:var(--displayed-side-length);
+  width:var(--displayed-side-length);
+
+  /* scale preview square */
+  transform-origin:0 0;
+  transform:scale(var(--scale-ratio));
+}
+
 #square {
   position:relative;
-  margin:15px auto;
-  width:500px;
-  height:500px;
+  width:var(--original-side-length);
+  height:var(--original-side-length);
   background-color:#1A1AD4;
 }
 

--- a/style.css
+++ b/style.css
@@ -5,13 +5,13 @@
           calc(var(--original-side-length) * var(--scale-ratio));
 }
 
-@media screen and (max-width: 520px) {
+@media screen and (max-width: 530px) {
   :root {
-    --scale-ratio: 0.55;
+    --scale-ratio: 0.65;
   }
 }
 
-@media screen and (max-width: 300px) {
+@media screen and (max-width: 350px) {
   :root {
     --scale-ratio: 0.4;
   }


### PR DESCRIPTION
スマートフォンで見やすいようにしました。

## 修正点

- 舘名板の一辺の長さが 500px 固定っぽかったので `transrate: scale(var(--scale-ratio))` で見た目を `--scale-ratio` 倍にできるようにしました
  - `--scale-ratio` は CSS 変数です
  - media query を使って横幅に応じて 0.65 倍, 0.4倍になるようにしています
  - `scale` を使うと html2canvas がバグるので、変換直前に 1 倍に戻して、変換直後に `--scale-ratio` 倍に戻るようにしています
    - これが原因で若干ちらつく、対応策が浮かばず……
- 画面の幅が狭いときに入力フォームが縦に並ぶようにしました
- iOS から見ると明朝体になるので font に `sans-selif` を指定しました

デカいプルリクで申し訳ないです